### PR TITLE
fix replay for Windows

### DIFF
--- a/ptgctl/core.py
+++ b/ptgctl/core.py
@@ -245,7 +245,7 @@ class API:
         # import websockets
         params_str = urlencode({k: v for k, v in params.items() if k and v is not None}) if params else ''
         headers = self._headers(headers)
-        url = os.path.join(self._wsurl, *map(str, url_parts)) + (f'?{params_str}' if params_str else '')
+        url = os.path.join(self._wsurl, *map(str, url_parts)).replace("\\","/") + (f'?{params_str}' if params_str else '')
         log.info('websocket connect: %s', url)
         # return websockets.connect(url, extra_headers=headers, **(connect_kwargs or {}))
         return cls(url, params=params, extra_headers=headers, **(connect_kwargs or {}))

--- a/ptgctl/core.py
+++ b/ptgctl/core.py
@@ -245,7 +245,9 @@ class API:
         # import websockets
         params_str = urlencode({k: v for k, v in params.items() if k and v is not None}) if params else ''
         headers = self._headers(headers)
-        url = os.path.join(self._wsurl, *map(str, url_parts)).replace("\\","/") + (f'?{params_str}' if params_str else '')
+        url = '/'.join((self._wsurl, *(str(u) for u in url_parts if u is not None)))
+        url += f'?{params_str}' if params_str else ''
+
         log.info('websocket connect: %s', url)
         # return websockets.connect(url, extra_headers=headers, **(connect_kwargs or {}))
         return cls(url, params=params, extra_headers=headers, **(connect_kwargs or {}))


### PR DESCRIPTION
Before fixing, the url will contain \ instead of / on Windows
![image](https://user-images.githubusercontent.com/14088697/198812470-c4804307-982f-4524-a725-b52d6402e659.png)

After fixing, the url is correct and the replay works as expected as shown in the screenshot below
![image](https://user-images.githubusercontent.com/14088697/198812511-1bf09fa2-ef19-47c9-a1bf-bd545ce09f11.png)

