### PR TITLE
Add exposure of the __version__ attribute

### DIFF
--- a/ptgctl/__init__.py
+++ b/ptgctl/__init__.py
@@ -1,1 +1,2 @@
+from .__version__ import __version__
 from .core import *


### PR DESCRIPTION
I had an issue building the documentation according to your readme. I found that the `__version__` attribute was not being exposed. This PR merely exposes that attribute via the `ptgctl/__init__.py` file.

I didn't change it here, but the hard-coded version in the conf file could also be removed in lieu of the version number being exported out of the package.